### PR TITLE
Fixed merge of options parameter for function generate()

### DIFF
--- a/tag_cloud.php
+++ b/tag_cloud.php
@@ -35,7 +35,7 @@ class TagCloudHelper extends AppHelper
          return;
       }
       
-      $this->options = array_merge($options, $this->options);
+      $this->options = array_merge($this->options, $options);
       $o = $this->options;
 		 
       $max_size = $o['max_font_size']; // max font size in pixels


### PR DESCRIPTION
Changed order of array_merge parameters to actually merge the options instead of overwriting them with the defaults.
